### PR TITLE
Refactor: Remove SpotterAI branding from UI

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
-# SpotterAI Trip Planner Backend
+# Trip Planner Backend
 
-REST API backend for SpotterAI’s US truck trip planning platform.
+REST API backend for US truck trip planning platform.
 
 - 🚚 **Route planning** via OpenRouteService (live geocoding/routing)
 - 🗺️ **Stops and route geometry** returned for map and ELD simulation

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,11 +6,11 @@
 
     <!-- Primary Meta Tags -->
     <title>
-      SpotterAI Trip Planner - HOS Compliant Trucking Route Planning
+      Trip Planner - HOS Compliant Trucking Route Planning
     </title>
     <meta
       name="title"
-      content="SpotterAI Trip Planner - HOS Compliant Trucking Route Planning"
+      content="Trip Planner - HOS Compliant Trucking Route Planning"
     />
     <meta
       name="description"
@@ -25,10 +25,10 @@
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://spotter-trip-planner.com/" />
+    <meta property="og:url" content="https://trip-planner.com/" />
     <meta
       property="og:title"
-      content="SpotterAI Trip Planner - HOS Compliant Trucking Route Planning"
+      content="Trip Planner - HOS Compliant Trucking Route Planning"
     />
     <meta
       property="og:description"
@@ -36,16 +36,16 @@
     />
     <meta
       property="og:image"
-      content="https://spotter-trip-planner.com/og-image.png"
+      content="https://trip-planner.com/og-image.png"
     />
-    <meta property="og:site_name" content="SpotterAI Trip Planner" />
+    <meta property="og:site_name" content="Trip Planner" />
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://spotter-trip-planner.com/" />
+    <meta property="twitter:url" content="https://trip-planner.com/" />
     <meta
       property="twitter:title"
-      content="SpotterAI Trip Planner - HOS Compliant Trucking Route Planning"
+      content="Trip Planner - HOS Compliant Trucking Route Planning"
     />
     <meta
       property="twitter:description"
@@ -60,8 +60,8 @@
     <!-- Additional SEO Meta Tags -->
     <meta name="theme-color" content="#2563eb" />
     <meta name="msapplication-TileColor" content="#2563eb" />
-    <meta name="application-name" content="SpotterAI Trip Planner" />
-    <meta name="apple-mobile-web-app-title" content="SpotterAI Trip Planner" />
+    <meta name="application-name" content="Trip Planner" />
+    <meta name="apple-mobile-web-app-title" content="Trip Planner" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
@@ -70,9 +70,9 @@
       {
         "@context": "https://schema.org",
         "@type": "WebApplication",
-        "name": "SpotterAI Trip Planner",
+        "name": "Trip Planner",
         "description": "Professional trucking route planner with US Hours of Service compliance and ELD log generation",
-        "url": "https://spotter-trip-planner.com",
+        "url": "https://trip-planner.com",
         "applicationCategory": "Transportation",
         "operatingSystem": "Web Browser",
         "author": {
@@ -108,7 +108,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://spotter-trip-planner.com/" />
+    <link rel="canonical" href="https://trip-planner.com/" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "SpotterAI Trip Planner",
-  "short_name": "SpotterAI",
+  "name": "Trip Planner",
+  "short_name": "TripPlanner",
   "description": "Professional trucking route planner with HOS compliance and ELD log generation",
   "start_url": "/",
   "display": "standalone",
@@ -45,14 +45,14 @@
       "sizes": "1280x720",
       "type": "image/png",
       "form_factor": "wide",
-      "label": "Desktop view of SpotterAI Trip Planner"
+      "label": "Desktop view of Trip Planner"
     },
     {
       "src": "/screenshot-mobile.png",
       "sizes": "390x844",
       "type": "image/png",
       "form_factor": "narrow",
-      "label": "Mobile view of SpotterAI Trip Planner"
+      "label": "Mobile view of Trip Planner"
     }
   ]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,7 +39,7 @@ export default function App() {
       {/* Header */}
       <header className="sticky top-0 z-20 bg-white/90 dark:bg-surface/90 shadow backdrop-blur flex items-center px-6 h-16">
         <span className="font-extrabold text-lg tracking-tight text-primary mr-4">
-          SpotterAI Trip Planner
+          Trip Planner
         </span>
         <nav className="ml-auto flex items-center space-x-2">
           <AboutDrawer />

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -12,7 +12,7 @@ export default function Home() {
       {/* Header */}
       <header className="sticky top-0 z-20 bg-white/90 dark:bg-surface/90 shadow backdrop-blur flex items-center px-6 h-16">
         <span className="font-extrabold text-lg tracking-tight text-primary mr-4">
-          SpotterAI Trip Planner
+          Trip Planner
         </span>
         <nav className="ml-auto flex items-center space-x-2">
           <AboutDrawer />

--- a/frontend/src/components/AboutDrawer.tsx
+++ b/frontend/src/components/AboutDrawer.tsx
@@ -38,7 +38,7 @@ export function AboutDrawer() {
               About & Help
             </Dialog.Title>
             <p className="text-base mb-2">
-              <strong>SpotterAI Trip Planner</strong> is a smart full-stack demo
+              <strong>Trip Planner</strong> is a smart full-stack demo
               for property-carrying truckers. Enter your route, and our AI plans
               a legal drive under US <b>Hours of Service (HOS)</b> rules, with
               ELD log sheets and map stops.


### PR DESCRIPTION
Replaced instances of 'SpotterAI' with 'Trip Planner' in UI elements and documentation. Updated relevant URLs accordingly.